### PR TITLE
⚡ Bolt: [performance improvement] O(N*M) query mapping bottleneck

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-29 - [O(n^2) Database Aggregation Bottleneck]
+**Learning:** Found an O(n^2) bottleneck when fetching all schedules. Instead of using a `JOIN` or aggregating properly in SQL, the application fetches all schedules and all checklist items, and then filters the checklist items in a nested loop in JavaScript for every schedule. This pattern scales poorly as schedules and checklist items grow.
+**Action:** Always group related child arrays using a hash map lookup (O(1)) instead of `.filter()` (O(N)) when merging two large query results in the backend.

--- a/backend/controllers/schedulesController.js
+++ b/backend/controllers/schedulesController.js
@@ -55,9 +55,19 @@ export const getAllSchedules = async (req, res) => {
         const schedules = scheduleResult.rows;
         const checklistItems = itemsResult.rows;
 
+        // ⚡ Bolt Optimization: Replaced O(N*M) nested loop (Array.filter) with O(N+M) hash map
+        // Reduces time complexity significantly when dealing with many schedules and items
+        const checklistItemsMap = checklistItems.reduce((acc, item) => {
+            if (!acc[item.schedule_id]) {
+                acc[item.schedule_id] = [];
+            }
+            acc[item.schedule_id].push(item);
+            return acc;
+        }, {});
+
         const schedulesWithItems = schedules.map(schedule => ({
             ...schedule,
-            checklist_items: checklistItems.filter(item => item.schedule_id === schedule.id)
+            checklist_items: checklistItemsMap[schedule.id] || []
         }));
 
         const groupedSchedules = schedulesWithItems.reduce((acc, schedule) => {


### PR DESCRIPTION
💡 **What:** Replaced a nested array filter inside a `.map()` loop with a pre-computed hash map (using `.reduce()`) in `backend/controllers/schedulesController.js` `getAllSchedules`. Added critical learning to `.jules/bolt.md`.
🎯 **Why:** The previous logic looped through all `checklist_items` for every single `schedule`, causing an $O(N \times M)$ performance bottleneck. Grouping by a hash map first ensures $O(1)$ lookups, reducing the time complexity to $O(N + M)$.
📊 **Impact:** Significantly reduces CPU overhead and latency of the `/api/schedules` endpoint, especially as the number of schedules and checklist items grows.
🔬 **Measurement:** Running tests via `cd backend && npm test` verifies the correct schedules with checklist items are still returned, and performance under heavy load can be measured with significantly shorter response times on the endpoint. 

No README updates required.

---
*PR created automatically by Jules for task [15859601279340804105](https://jules.google.com/task/15859601279340804105) started by @bodybuildingfly*