### PR TITLE
🔒 Fix hardcoded JWT secret default and enforce fail-fast startup

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -9,7 +9,7 @@ import pool from '../db.js';
  * @returns {string} The signed JWT.
  */
 const generateToken = (id) => {
-    return jwt.sign({ id }, process.env.JWT_SECRET || 'your_default_jwt_secret', {
+    return jwt.sign({ id }, process.env.JWT_SECRET, {
         expiresIn: '15m', // Access token expires in 15 minutes
     });
 };

--- a/backend/middleware/authMiddleware.js
+++ b/backend/middleware/authMiddleware.js
@@ -20,7 +20,7 @@ export const protect = async (req, res, next) => {
 
             // Verify the token using a secret key. We'll need to add this to our settings.
             // For now, we can use a placeholder or an environment variable.
-            const decoded = jwt.verify(token, process.env.JWT_SECRET || 'your_default_jwt_secret');
+            const decoded = jwt.verify(token, process.env.JWT_SECRET);
 
             // Find the user by the ID from the token payload and attach it to the request.
             // This makes the user's info available to all subsequent protected routes.

--- a/backend/middleware/authMiddleware.test.js
+++ b/backend/middleware/authMiddleware.test.js
@@ -44,7 +44,7 @@ describe('Auth Middleware', () => {
 
       await protect(req, res, next);
 
-      expect(jwt.verify).toHaveBeenCalledWith(mockToken, process.env.JWT_SECRET || 'your_default_jwt_secret');
+      expect(jwt.verify).toHaveBeenCalledWith(mockToken, process.env.JWT_SECRET);
       expect(pool.query).toHaveBeenCalledWith('SELECT id, username, role FROM users WHERE id = $1', [1]);
       expect(req.user).toEqual(mockUser);
       expect(next).toHaveBeenCalled();

--- a/backend/server.js
+++ b/backend/server.js
@@ -83,6 +83,13 @@ if (process.env.NODE_ENV === 'production') {
  * @description The main application start function.
  */
 const startServer = async () => {
+    // Fail-fast on critical missing environment variables
+    if (!process.env.JWT_SECRET) {
+        console.error('[CRITICAL] JWT_SECRET environment variable is not defined.');
+        console.error('The server cannot start securely without a JWT_SECRET.');
+        process.exit(1);
+    }
+
     try {
         await initializeDatabase();
         appSettings = await loadSettings();


### PR DESCRIPTION
🎯 **What:** Removed hardcoded `JWT_SECRET` defaults in `authController.js` and `authMiddleware.js`. Added a fail-fast mechanism on startup if `process.env.JWT_SECRET` is missing.
⚠️ **Risk:** Hardcoded default secrets are trivial to exploit. An attacker knowing the default string could forge valid JWTs and bypass authentication controls, leading to critical data compromise.
🛡️ **Solution:** Removed the default string fallback in JWT generation and verification. Enforced a required `JWT_SECRET` environment variable during the application bootstrap (`server.js`) that safely stops the process when absent, maintaining secure practices. Updated corresponding tests to verify changes safely. No README updates needed since `JWT_SECRET` is already stated as required.

---
*PR created automatically by Jules for task [11031803963843752243](https://jules.google.com/task/11031803963843752243) started by @bodybuildingfly*