### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix insecure default admin credentials

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Internal database error messages were leaked to the frontend client in error responses (e.g., `details: err.message`).
 **Learning:** Returning unhandled exception messages directly in API responses can leak sensitive database/infrastructure information to attackers.
 **Prevention:** Ensure API endpoints return generic error messages (e.g., "Internal server error") and only log detailed exceptions securely on the server side using the application logger.
+
+## 2025-02-27 - [Hardcoded Admin Credentials]
+**Vulnerability:** Initial admin account fallback to hardcoded `changeme` password.
+**Learning:** Default fallback passwords on startup provide an insecure backdoor if administrators fail to configure credentials.
+**Prevention:** Follow a strict fail-fast approach for required secrets (like admin passwords or JWT secrets). Throw a fatal error on startup instead of providing weak defaults.

--- a/backend/db.js
+++ b/backend/db.js
@@ -48,15 +48,12 @@ const createInitialAdmin = async (client) => {
     console.log('[INFO] No admin user found. Creating initial admin account...');
 
     const adminUser = process.env.ADMIN_USERNAME || 'admin';
-    const adminPass = process.env.ADMIN_PASSWORD || 'changeme';
 
     if (!process.env.ADMIN_PASSWORD) {
-        console.warn('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
-        console.warn('!!! WARNING: Using default admin password.                 !!!');
-        console.warn('!!! Please set the ADMIN_PASSWORD environment variable.    !!!');
-        console.warn(`!!! Default credentials: ${adminUser} / ${adminPass}                !!!`);
-        console.warn('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
+        throw new Error('ADMIN_PASSWORD environment variable is required to create the initial admin account.');
     }
+
+    const adminPass = process.env.ADMIN_PASSWORD;
 
     const salt = await bcrypt.genSalt(10);
     const passwordHash = await bcrypt.hash(adminPass, salt);


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The application was falling back to a hardcoded 'changeme' password if an administrator failed to provide the ADMIN_PASSWORD environment variable during startup.
🎯 **Impact:** An attacker could gain full administrative access if the application was deployed without properly configuring the administrator password.
🔧 **Fix:** Replaced the insecure fallback with a strict fail-fast validation that prevents the server from creating the initial admin account and throws a fatal error if the required ADMIN_PASSWORD environment variable is missing.
✅ **Verification:** Ran tests with the new setup and they correctly passed; verifying code fails when expected if the credentials are not provided.

---
*PR created automatically by Jules for task [13973701349954600282](https://jules.google.com/task/13973701349954600282) started by @bodybuildingfly*